### PR TITLE
Fix synchronous fetch for vim

### DIFF
--- a/autoload/pivotaltracker.vim
+++ b/autoload/pivotaltracker.vim
@@ -116,6 +116,10 @@ func! s:fetch() abort
             return []
         endif
     else
+        if !has('nvim')
+            " convert l:cmd to string because vim's system() api does not like lists
+            let l:cmd = '"' . join(l:cmd, '" "') . '"'
+        endif
         return s:parse(system(l:cmd))
     endif
 endfunc


### PR DESCRIPTION
Fixes #1 

It seems that Neovim accepts lists as the `system()` param whereas Vim only accepts strings. It probably worked fine on Neovim but never got properly tested in Vim.